### PR TITLE
Fix for Floating IP, SSH, and Volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ocean_kit = OceanKit::Client.new("API-KEY")
 ### Floating Ip
 * `ocean_kit.floating_ip_actions.attach(ip, droplet_id)`
 * `ocean_kit.floating_ip_actions.deattach(id)`
-* `ocean_kit.floating_ips.all(ip)`
+* `ocean_kit.floating_ips.all`
 * `ocean_kit.floating_ips.cretate(droplet_id)`
 * `ocean_kit.floating_ips.find(floating_ip)`
 * `ocean_kit.floating_ips.delete(floating_ip)`
@@ -139,11 +139,11 @@ ocean_kit = OceanKit::Client.new("API-KEY")
 
 
 ### SSH Key
-* `ocean_kit.ssh_key.all`
-* `ocean_kit.ssh_key.create(name, public_key)`
-* `ocean_kit.ssh_key.find(id)`
-* `ocean_kit.ssh_key.delete(id)`
-* `ocean_kit.ssh_key.update(id)`
+* `ocean_kit.ssh_keys.all`
+* `ocean_kit.ssh_keys.create(name, public_key)`
+* `ocean_kit.ssh_keys.find(id)`
+* `ocean_kit.ssh_keys.delete(id)`
+* `ocean_kit.ssh_keys.update(id)`
 
 ### Volume Action
 * `ocean_kit.volume_actions.attach(volume_id, droplet_id)`

--- a/README.md
+++ b/README.md
@@ -170,3 +170,4 @@ ocean_kit = OceanKit::Client.new("API-KEY")
 ## Contributors
 
 - [osfx](https://github.com/osfx) osfx - creator, maintainer
+- [abudhu](https://github.com/abudhu) abudhu - contributor

--- a/src/ocean_kit/client.cr
+++ b/src/ocean_kit/client.cr
@@ -6,7 +6,8 @@ module OceanKit
       "domain" => :Domain, "domain_record" => :DomainRecord, "droplet_action" => :DropletAction,
       "floating_ip_action" => :FloatingIpAction, "floating_ip" => :FloatingIps,
       "image_action" => :ImageAction, "image" => :Image, "region" => :Region, "size" => :Size,
-      "snapshot" => :Snapshot, "ssh_key" => :SSHKey, "volume_action" => :VolumeAction
+      "snapshot" => :Snapshot, "ssh_key" => :SSHKey, "volume_action" => :VolumeAction,
+      "volume" => :Volume
     }
 
     def initialize(api_key : String)

--- a/src/ocean_kit/client.cr
+++ b/src/ocean_kit/client.cr
@@ -4,7 +4,7 @@ module OceanKit
   class Client
     RESOURCES = {
       "domain" => :Domain, "domain_record" => :DomainRecord, "droplet_action" => :DropletAction,
-      "floating_ip_action" => :FloatingIpAction, "floating_ip" => :FloatingIp,
+      "floating_ip_action" => :FloatingIpAction, "floating_ip" => :FloatingIps,
       "image_action" => :ImageAction, "image" => :Image, "region" => :Region, "size" => :Size,
       "snapshot" => :Snapshot, "ssh_key" => :SSHKey, "volume_action" => :VolumeAction
     }

--- a/src/ocean_kit/resources/floating_ips.cr
+++ b/src/ocean_kit/resources/floating_ips.cr
@@ -14,8 +14,8 @@ module OceanKit
       end
       # List all of the Floating IPs available on your account
       #
-      def all(ip)
-        post("/floating_ips")
+      def all
+        get("/floating_ips")
       end
       # On creation, a Floating IP must be either assigned
       # to a Droplet or reserved to a region


### PR DESCRIPTION
FloatingIp class was misnamed in RESOURCES field causing it to fail.  Additionally it was a POST command requiring an IP parameter.  This fixes the functionality to match what is expected from requesting all floating IPs

Fixed syntax for ssh_key(s) in the Readme

Volume wasn't a valid method as it was not part of the known RESOURCES